### PR TITLE
[Enhancement] Create Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 
 ### Short Summary
 
-### Occurencies
+### Occurrences
 
 * [ ] always
 * [ ] special use cases:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+
+name: Bug Report
+about: Report an encountered bug.
+title: '[Bug] '
+labels:
+  - bug
+assignees: ''
+
+---
+
+### Short Summary
+
+### Occurencies
+
+* [ ] always
+* [ ] special use cases:
+  * [ ] operating systems:
+    * ...
+  * [ ] option combinations:
+    * ...
+  * [ ] other:
+    * ...
+* [ ] other:
+  * ...
+
+### Expected Reasons
+
+* [ ] unknown
+* [ ] issues:
+  * ...
+* [ ] pull requests:
+  * ...
+* [ ] other:
+  * ...
+
+### Further Readings
+
+* ...

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,9 @@
+---
+
+name: Default
+about: A generic issue.
+labels: ''
+assignees: ''
+title: ''
+
+---


### PR DESCRIPTION
With issue templates, typical reasons for raising issues can be handled by creating categories for them and configuring sane initial settings.

This Pull Request introduces a sane set of initial templates in order to make handling new issues easier.